### PR TITLE
Feature issue 127 group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
     # Raise pull requests for version updates
     # to pip against the `develop` branch
     target-branch: "develop"
@@ -11,4 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      gha-dependencies:
+        patterns:
+          - "*"
     target-branch: "develop"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- [issue #127](https://github.com/nasa/batchee/issues/127): Group dependabot updates into fewer PRs
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
 ## [1.1.0]
 
 ### Added


### PR DESCRIPTION
GitHub Issue: #127 
### Description

This change rolls up the dependabot updates into a single PR for pip and a single PR for GitHub Actions.

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [n/a] Documentation updated (if needed).
