### PR TITLE
Feature/issue 129 add autoupdate for pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_schedule: "monthly" # Like dependabot
   autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autoupdate_branch: "develop"
   autofix_prs: false # Comment "pre-commit.ci autofix" on a PR to trigger
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
----
+ci:
+  autoupdate_schedule: "monthly" # Like dependabot
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_prs: false # Comment "pre-commit.ci autofix" on a PR to trigger
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [issue #127](https://github.com/nasa/batchee/issues/127): Group dependabot updates into fewer PRs
+- [issue #129](https://github.com/nasa/batchee/issues/129): Add autoupdate schedule for pre-commit
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
GitHub Issue: #129 

### Description

This change adds an autoupdate schedule for pre-commit CI.

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [n/a] Documentation updated (if needed).
