### PR TITLE
Fix deprecated ruff syntax in run_tests.yml

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Lint
         run: |
-          poetry run ruff batcher
+          poetry run ruff check batcher
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
Followup to #138 