### PR TITLE
Issue 176: grouping using day in US/Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- update grouping algorithm to use day in US Central as the first part of unique grouping identifier ([#177](https://github.com/nasa/batchee/pull/177))([**@ank1m**](https://github.com/ank1m))
+
 ## [1.3.0] - 2024-11-19
 
 ### Changed

--- a/batcher/tempo_filename_parser.py
+++ b/batcher/tempo_filename_parser.py
@@ -30,6 +30,7 @@ import logging
 import re
 from argparse import ArgumentParser
 from datetime import datetime
+
 from dateutil import tz
 
 default_logger = logging.getLogger(__name__)

--- a/batcher/tempo_filename_parser.py
+++ b/batcher/tempo_filename_parser.py
@@ -30,8 +30,7 @@ import logging
 import re
 from argparse import ArgumentParser
 from datetime import datetime
-
-from dateutil import tz
+from zoneinfo import ZoneInfo
 
 default_logger = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ tempo_granule_filename_pattern = re.compile(
     r"(?P<granule_id>G[0-9]{2}).*\.nc"
 )
 
-def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=tz.UTC) -> str:
+def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=ZoneInfo("UTC")) -> str:
     """
     Convert a datetime to US Central time (US/Central) and return
     a timezone-aware datetime.
@@ -71,7 +70,7 @@ def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=t
     dt = datetime.strptime(day_in_granule+time_in_granule, "%Y%m%d%H%M%S")
     dt = dt.replace(tzinfo = assume_tz)
 
-    dt_central = dt.astimezone(tz.gettz('US/Central'))
+    dt_central = dt.astimezone(ZoneInfo("US/Central"))
     return dt_central.strftime("%Y%m%d")
 
 

--- a/batcher/tempo_filename_parser.py
+++ b/batcher/tempo_filename_parser.py
@@ -46,7 +46,10 @@ tempo_granule_filename_pattern = re.compile(
     r"(?P<granule_id>G[0-9]{2}).*\.nc"
 )
 
-def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=ZoneInfo("UTC")) -> str:
+
+def get_day_in_us_central(
+    day_in_granule: str, time_in_granule: str, assume_tz=ZoneInfo("UTC")
+) -> str:
     """
     Convert a datetime to US Central time (US/Central) and return
     a timezone-aware datetime.
@@ -67,8 +70,8 @@ def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=Z
         The day for datetime converted to US/Central
     """
 
-    dt = datetime.strptime(day_in_granule+time_in_granule, "%Y%m%d%H%M%S")
-    dt = dt.replace(tzinfo = assume_tz)
+    dt = datetime.strptime(day_in_granule + time_in_granule, "%Y%m%d%H%M%S")
+    dt = dt.replace(tzinfo=assume_tz)
 
     dt_central = dt.astimezone(ZoneInfo("US/Central"))
     return dt_central.strftime("%Y%m%d")
@@ -89,7 +92,9 @@ def get_batch_indices(filenames: list, logger: logging.Logger = default_logger) 
         matches = tempo_granule_filename_pattern.match(name)
         if matches:
             match_dict = matches.groupdict()
-            day_in_central= get_day_in_us_central(match_dict["day_in_granule"], match_dict["time_in_granule"])
+            day_in_central = get_day_in_us_central(
+                match_dict["day_in_granule"], match_dict["time_in_granule"]
+            )
             day_and_scans.append((day_in_central, match_dict["daily_scan_id"]))
 
     # Unique day-scans are determined (while keeping the same order). Each will be its own batch.

--- a/batcher/tempo_filename_parser.py
+++ b/batcher/tempo_filename_parser.py
@@ -60,9 +60,9 @@ def get_day_in_us_central(
         The day from granule filename
     time_in_granule: str
         The time from granule filename
-    assume_tz : timezon, optional (default: UTC)
-        this is the timezone in which `dt` should be interpreted
-        before converting to Central.
+    assume_tz : timezone, optional (default: UTC)
+        this is the timezone in which `day_in_granule` and `time_in_granule`
+        should be interpreted before converting to Central.
 
     Returns
     -------
@@ -73,7 +73,7 @@ def get_day_in_us_central(
     dt = datetime.strptime(day_in_granule + time_in_granule, "%Y%m%d%H%M%S")
     dt = dt.replace(tzinfo=assume_tz)
 
-    dt_central = dt.astimezone(ZoneInfo("US/Central"))
+    dt_central = dt.astimezone(ZoneInfo("America/Chicago"))
     return dt_central.strftime("%Y%m%d")
 
 

--- a/batcher/tempo_filename_parser.py
+++ b/batcher/tempo_filename_parser.py
@@ -29,6 +29,8 @@
 import logging
 import re
 from argparse import ArgumentParser
+from datetime import datetime
+from dateutil import tz
 
 default_logger = logging.getLogger(__name__)
 
@@ -43,6 +45,33 @@ tempo_granule_filename_pattern = re.compile(
     r"(?P<daily_scan_id>S[0-9]{3})"
     r"(?P<granule_id>G[0-9]{2}).*\.nc"
 )
+
+def get_day_in_us_central(day_in_granule: str, time_in_granule: str, assume_tz=tz.UTC) -> str:
+    """
+    Convert a datetime to US Central time (US/Central) and return
+    a timezone-aware datetime.
+
+    Parameters
+    ----------
+    day_in_granule: str
+        The day from granule filename
+    time_in_granule: str
+        The time from granule filename
+    assume_tz : timezon, optional (default: UTC)
+        this is the timezone in which `dt` should be interpreted
+        before converting to Central.
+
+    Returns
+    -------
+    str
+        The day for datetime converted to US/Central
+    """
+
+    dt = datetime.strptime(day_in_granule+time_in_granule, "%Y%m%d%H%M%S")
+    dt = dt.replace(tzinfo = assume_tz)
+
+    dt_central = dt.astimezone(tz.gettz('US/Central'))
+    return dt_central.strftime("%Y%m%d")
 
 
 def get_batch_indices(filenames: list, logger: logging.Logger = default_logger) -> list[int]:
@@ -60,7 +89,8 @@ def get_batch_indices(filenames: list, logger: logging.Logger = default_logger) 
         matches = tempo_granule_filename_pattern.match(name)
         if matches:
             match_dict = matches.groupdict()
-            day_and_scans.append((match_dict["day_in_granule"], match_dict["daily_scan_id"]))
+            day_in_central= get_day_in_us_central(match_dict["day_in_granule"], match_dict["time_in_granule"])
+            day_and_scans.append((day_in_central, match_dict["daily_scan_id"]))
 
     # Unique day-scans are determined (while keeping the same order). Each will be its own batch.
     unique_day_scans: list[tuple[str, str]] = sorted(set(day_and_scans), key=day_and_scans.index)

--- a/tests/test_filename_grouping.py
+++ b/tests/test_filename_grouping.py
@@ -2,22 +2,29 @@ import sys
 from unittest.mock import patch
 
 import batcher.tempo_filename_parser
-from batcher.tempo_filename_parser import get_batch_indices
+from batcher.tempo_filename_parser import get_batch_indices, get_day_in_us_central
 
 example_filenames = [
-    "TEMPO_HCHO_L2_V01_20130701T212354Z_S009G05.nc",
-    "TEMPO_HCHO_L2_V01_20130701T212953Z_S009G06.nc",
-    "TEMPO_HCHO_L2_V01_20130701T213553Z_S009G07.nc",
-    "TEMPO_HCHO_L2_V01_20130701T215955Z_S010G01.nc",
-    "TEMPO_HCHO_L2_V01_20130701T220554Z_S010G02.nc",
-    "TEMPO_HCHO_L2_V01_20130701T221154Z_S010G03.nc",
+    "TEMPO_NO2_L2_V03_20240731T235252Z_S016G04.nc",
+    "TEMPO_NO2_L2_V03_20240731T235929Z_S016G05.nc",
+    "TEMPO_NO2_L2_V03_20240801T000606Z_S016G06.nc",
+    "TEMPO_NO2_L2_V03_20240801T001302Z_S017G01.nc",
+    "TEMPO_NO2_L2_V03_20240801T001942Z_S017G02.nc",
+    "TEMPO_NO2_L2_V03_20240801T002619Z_S017G03.nc",
+    "TEMPO_NO2_L2_V03_20240801T233313Z_S016G01.nc",
+    "TEMPO_NO2_L2_V03_20240801T233953Z_S016G02.nc",
+    "TEMPO_NO2_L2_V03_20240801T234630Z_S016G03.nc",
 ]
 
+def test_timezone_conversion():
+    utcdates = [filename.split('_')[4] for filename in example_filenames]
+    days_in_central = [get_day_in_us_central(utcdt[0:8], utcdt[9:15]) for utcdt in utcdates]
+    assert days_in_central == ["20240731", "20240731", "20240731", "20240731", "20240731", "20240731", "20240801", "20240801", "20240801"]
 
 def test_grouping():
     results = get_batch_indices(example_filenames)
 
-    assert results == [0, 0, 0, 1, 1, 1]
+    assert results == [0, 0, 0, 1, 1, 1, 2, 2, 2]
 
 
 def test_main_cli():
@@ -27,4 +34,4 @@ def test_main_cli():
     with patch.object(sys, "argv", test_args):
         grouped_names = batcher.tempo_filename_parser.main()
 
-    assert grouped_names == [example_filenames[0:3], example_filenames[3:6]]
+    assert grouped_names == [example_filenames[0:3], example_filenames[3:6], example_filenames[6:9]]

--- a/tests/test_filename_grouping.py
+++ b/tests/test_filename_grouping.py
@@ -16,10 +16,22 @@ example_filenames = [
     "TEMPO_NO2_L2_V03_20240801T234630Z_S016G03.nc",
 ]
 
+
 def test_timezone_conversion():
-    utcdates = [filename.split('_')[4] for filename in example_filenames]
+    utcdates = [filename.split("_")[4] for filename in example_filenames]
     days_in_central = [get_day_in_us_central(utcdt[0:8], utcdt[9:15]) for utcdt in utcdates]
-    assert days_in_central == ["20240731", "20240731", "20240731", "20240731", "20240731", "20240731", "20240801", "20240801", "20240801"]
+    assert days_in_central == [
+        "20240731",
+        "20240731",
+        "20240731",
+        "20240731",
+        "20240731",
+        "20240731",
+        "20240801",
+        "20240801",
+        "20240801",
+    ]
+
 
 def test_grouping():
     results = get_batch_indices(example_filenames)


### PR DESCRIPTION
GitHub Issue: #176

### Description

Modifies grouping algorithm to use day in US Central as the first part of unique grouping identifier. The second part is the scan number.

### Local test steps

- Pulled all tempo filenames in PROD and ran collision check.
- Tested new algorithm on the filenames that cause collisions and confirmed that they are resolved.

### Overview of integration done

Ran updated version of batchee in Local Harmony-in-a-box environment and confirmed that new grouping algorithm works as expected.

<img width="640" src="https://github.com/user-attachments/assets/7e946051-520d-4bb2-a49e-532a3fd8a7f7" />

<img width="640" alt="image" src="https://github.com/user-attachments/assets/3b1aeb43-8937-4fc0-8e13-b4f9a31108bf" />


_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).
